### PR TITLE
Add booking actions

### DIFF
--- a/src/components/rockets/Rockets.js
+++ b/src/components/rockets/Rockets.js
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import { useSelector, useDispatch } from "react-redux";
-import { fetchRockets } from "../../redux/rockets/rocketSlice";
+import { fetchRockets, bookRockets } from "../../redux/rockets/rocketSlice";
 
 const Rockets = () => {
   const { rockets, status } = useSelector((state) => state.rockets);
@@ -11,6 +11,10 @@ const Rockets = () => {
       dispatch(fetchRockets());
     }
   }, [status, dispatch]);
+
+  const BookingHandler = (id) => {
+    dispatch(bookRockets(id));
+  }
   
   let content;
   if (status === 'pending') {
@@ -23,7 +27,7 @@ const Rockets = () => {
 
   return (
     <div>
-      {content}
+      { content }
       <div className="rocketList">
         {rockets.map((rocket) => (
           <div key={rocket.id} className="rocketCard">
@@ -32,11 +36,12 @@ const Rockets = () => {
               <h3 className="rocketName">{rocket.rocket_name}</h3>
               <div className="rocketDesc">
                 <p>
-                  <span className="status">status</span>
-                  <span>{rocket.description}</span>
+                  {rocket.active && <span className="status">Reserved</span>}
+                  {rocket.description}
                 </p>
               </div>
-              <button type="submit">Reserve Rocket</button>
+              <button id={rocket.id} type="submit" onClick={() => BookingHandler(rocket.id)}>
+                {rocket.active ? 'Cancel Reservations' : 'Reserve Rockets'}</button>
             </div>
           </div>
         ))}

--- a/src/redux/rockets/rocketSlice.js
+++ b/src/redux/rockets/rocketSlice.js
@@ -26,7 +26,21 @@ export const fetchRockets = createAsyncThunk(
 const slice = createSlice({
   name: "rockets",
   initialState,
-  reducer: {},
+  reducers: {
+    bookRockets: (state, action) => ({
+      ...state,
+      rockets: state.rockets.map((rocket) => {
+        if (rocket.id === action.payload) {
+        return { 
+          ...rocket,
+           active: !rocket.active, 
+          };
+      };
+      return { ...rocket };
+      }),
+    }),
+  },
+
   extraReducers(builder) {
     builder
       .addCase(fetchRockets.pending, (state) => {
@@ -37,7 +51,19 @@ const slice = createSlice({
         const IsSucessful = state;
         IsSucessful.status = 'success';
         IsSucessful.rockets = action.payload;
-       })
+
+      //  const rocketsArr = [];
+      //   action.payload.map((rocket) => rocketsArr.push({
+      //     id: rocket.id,
+      //     rocketName: rocket.rocket_name,
+      //     rocketDesc: rocket.description,
+      //     rocketImages: rocket.flickr_images,
+      //     reserved: false,
+      //   }));
+      //   IsSucessful.rockets = rocketsArr;
+
+    
+      })
 
       .addCase(fetchRockets.rejected, (state) => {
         const IsRejected = state;
@@ -46,5 +72,5 @@ const slice = createSlice({
   },
 });
 
-
+export const { bookRockets } = slice.actions;
 export default slice.reducer;


### PR DESCRIPTION
## In this pull request, I implemented the following:

- When a user clicks the "Reserve rocket" button, action is dispatched to update the store.
- Rockets that have already been reserved showed a "Reserved" badge and "Cancel reservation" button instead of the default "Reserve rocket" (as per design) when clicked.